### PR TITLE
fix(workflow): remove push event, don't run on draft

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,15 +4,15 @@
 name: Java CI with Maven
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
+    types: [ opened, reopened, synchronize, ready_for_review ]
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Running on pushes to master is unnecessary.
There should never be pushes directly on master, only PRs.
Also don't create a pre-release on drafts, as draft are usually WIP and could break dev builds.