### PR TITLE
ci: fix release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,6 @@
 changelog:
   exclude:
-    - labels:
+    labels:
       - ignore-notes
   categories:
     - title: Bug Fixes
@@ -24,3 +24,6 @@ changelog:
     - title: Documentation
       labels:
         - docs
+    - title: 'Other Changes'
+      labels:
+        - "*"


### PR DESCRIPTION
There was a typo in the release.yml which caused UncaughtPromiseRejections on workflows.
Could try the first fork again, but it should work now (hopefully) and I'm not in the mood the revert changes.