### PR TITLE
ci: Use fixed workflow, change artifacts to SNAPSHOT

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,10 +29,10 @@ jobs:
       run: mvn -Dchangelist=-dev package
     - uses: actions/upload-artifact@v3
       with:
-        name: dynmap-mobs-dev
+        name: dynmap-mobs-SNAPSHOT
         path: /home/runner/work/dynmap-mobs/dynmap-mobs/target/dynmap-mobs-*.jar
     # Use fork supporting release notes
-    - uses: "lauravuo/action-automatic-releases@test-changes"
+    - uses: "Plastikmensch/action-automatic-releases@fixed"
       # Don't create dev release on PR
       if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
       with:


### PR DESCRIPTION
Signed-off-by: Plastikmensch <plastikmensch@users.noreply.github.com>

<!-- If this PR is related to an issue, link them below this comment as described in https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Ref #17 

<!-- Describe your changes -->
Workflow had a bug, which prevented the releaseTitle to apply to dev releases.
Use own fork with bug fixes instead.
Also changed the name of artifacts from -dev to -SNAPSHOT.

This should end the saga of workflow fixes.

